### PR TITLE
misc attribute is not always present

### DIFF
--- a/stanza_batch/__init__.py
+++ b/stanza_batch/__init__.py
@@ -158,11 +158,12 @@ def _batch_to_documents(
             sentence_dicts: List[Dict[str, str]] = []
             sentence_sentiment = getattr(sentence, "sentiment", None)
             for token in sentence.to_dict():
-                token_misc = token["misc"]
-                start, end = _start_end_character_offsets(token_misc)
-                start = start - start_offset
-                end = end - start_offset
-                token["misc"] = f"start_char={start}|end_char={end}"
+                if "misc" in token:
+                    token_misc = token["misc"]
+                    start, end = _start_end_character_offsets(token_misc)
+                    start = start - start_offset
+                    end = end - start_offset
+                    token["misc"] = f"start_char={start}|end_char={end}"
                 token["sentence_sentiment"] = sentence_sentiment
                 sentence_dicts.append(token)
             all_sentence_dicts.append(sentence_dicts)
@@ -263,11 +264,12 @@ def combine_stanza_documents(stanza_documents: List[Document]) -> Document:
             sentence_dicts: List[Dict[str, str]] = []
             sentence_sentiment = getattr(sentence, "sentiment", None)
             for token in sentence.to_dict():
-                token_misc = token["misc"]
-                start, end = _start_end_character_offsets(token_misc)
-                start = start + offset_to_add
-                end = end + offset_to_add
-                token["misc"] = f"start_char={start}|end_char={end}"
+                if "misc" in token:
+                    token_misc = token["misc"]
+                    start, end = _start_end_character_offsets(token_misc)
+                    start = start + offset_to_add
+                    end = end + offset_to_add
+                    token["misc"] = f"start_char={start}|end_char={end}"
                 token["sentence_sentiment"] = sentence_sentiment
                 sentence_dicts.append(token)
             all_sentence_dicts.append(sentence_dicts)


### PR DESCRIPTION
For parts of multi-word tokens, the `misc` attribute is not present (since these "subtokens" don't really exist in the text). This is just a small workaround for that situation.

How to test:

```python
import stanza
import stanza_batch

stanza.download('cs')
nlp = stanza.Pipeline('cs')

sent = 'Požádal, aby mu vyhověli.'
print(nlp(sent))

print(next(stanza_batch.batch([sent], nlp)))
```

Great package btw, I was really happy to find a batching implementation for Stanza.